### PR TITLE
Add chat memory and guardrail flows for Go

### DIFF
--- a/go/cookbook/README.md
+++ b/go/cookbook/README.md
@@ -1,0 +1,27 @@
+# PocketFlow Go Cookbook
+
+This cookbook collects example flows implemented with the Go version of PocketFlow.
+Each example demonstrates a particular feature or pattern.
+
+| Example | Description |
+|---------|-------------|
+| [QA](./qa) | Basic question answering flow using the event driven system |
+| [Branching](./branching) | Intent classifier with multiple response paths |
+| [Memory](./memory) | Chat application that keeps short-term context |
+| [Guardrail](./guardrail) | Travel chat with simple validation |
+
+Run examples from the `go` directory. For instance:
+
+```bash
+# Run the QA flow
+go run main.go --flow=qa
+
+# Run the branching flow
+go run main.go --flow=branching
+
+# Run the memory flow
+go run main.go --flow=memory
+
+# Run the guardrail flow
+go run main.go --flow=guardrail
+```

--- a/go/cookbook/branching/README.md
+++ b/go/cookbook/branching/README.md
@@ -1,0 +1,26 @@
+# Branching Intent Flow
+
+Demonstrates branching logic using an intent classifier. Depending on the detected
+intent, the flow routes to different handlers.
+
+## Run It
+
+From the `go` directory:
+
+```bash
+go run main.go --flow=branching
+```
+
+## How It Works
+
+```mermaid
+flowchart TD
+    input[User Input] --> classifier[Intent Classifier]
+    classifier -->|weather_intent| weather[Weather]
+    classifier -->|time_intent| time[Time]
+    classifier -->|help_intent| help[Help]
+    classifier -->|general_intent| general[General]
+```
+
+- **Intent Classifier** – examines the user's request.
+- **Weather/Time/Help/General** – provide different responses based on the intent.

--- a/go/cookbook/guardrail/README.md
+++ b/go/cookbook/guardrail/README.md
@@ -1,0 +1,27 @@
+# Chat Guardrail Flow
+
+This flow restricts user queries to travel topics using a validation step before processing with a mock LLM.
+
+## Run It
+
+From the `go` directory:
+
+```bash
+# visualize the flow
+go run main.go --flow=guardrail --visualize
+
+# execute the flow
+go run main.go --flow=guardrail
+```
+
+## How It Works
+
+```mermaid
+flowchart LR
+    input[UserInput] -->|validate| guard[Guardrail]
+    guard -->|process| llm[LLM]
+    guard -->|retry| input
+    llm -->|continue| input
+```
+
+The `GuardrailHandler` performs simple checks to ensure the prompt is travel related. Valid queries are answered by the `LLMHandler`; invalid ones cause the flow to retry.

--- a/go/cookbook/memory/README.md
+++ b/go/cookbook/memory/README.md
@@ -1,0 +1,33 @@
+# Chat Memory Flow
+
+This example demonstrates a simple chat application that keeps a short history of the conversation and archives older messages. It mirrors the Python memory cookbook but is implemented using PocketFlow Go.
+
+## Run It
+
+From the `go` directory:
+
+```bash
+# visualize the flow
+go run main.go --flow=memory --visualize
+
+# execute the flow
+go run main.go --flow=memory
+```
+
+## How It Works
+
+```mermaid
+flowchart LR
+    question[Question] -->|retrieve| retrieve[Retrieve]
+    retrieve -->|answer| answer[Answer]
+    answer -->|embed| embed[Embed]
+    answer -->|question| question
+    embed -->|question| question
+```
+
+The handlers simulate:
+
+- Asking a question (`QuestionHandler`)
+- Searching archived conversations for relevant context (`RetrieveHandler`)
+- Responding with a mock LLM while managing message history (`AnswerHandler`)
+- Archiving old messages when the active window exceeds three pairs (`EmbedHandler`)

--- a/go/cookbook/qa/README.md
+++ b/go/cookbook/qa/README.md
@@ -1,0 +1,24 @@
+# Question Answering Flow
+
+This example showcases a simple question answering agent built with PocketFlow Go.
+It asks a question and generates an answer using a mock LLM.
+
+## Run It
+
+From the `go` directory:
+
+```bash
+go run main.go --flow=qa
+```
+
+## How It Works
+
+The flow consists of two nodes:
+
+```mermaid
+flowchart LR
+    question[Question] --> answer[Answer]
+```
+
+1. **Question** – prompts the user for a question (simulated in the example).
+2. **Answer** – uses an LLM interface to produce a response.

--- a/go/event/examples/guardrail/guardrail_flow.go
+++ b/go/event/examples/guardrail/guardrail_flow.go
@@ -1,0 +1,78 @@
+package guardrail
+
+import (
+	"github.com/The-Pocket/PocketFlow/go/event/core"
+	"github.com/The-Pocket/PocketFlow/go/event/impl"
+	"strings"
+)
+
+// Ensure implementations
+var _ core.SimpleNodeHandler = (*InputHandler)(nil)
+var _ core.SimpleNodeHandler = (*GuardrailHandler)(nil)
+var _ core.SimpleNodeHandler = (*LLMHandler)(nil)
+
+type InputHandler struct{}
+
+func (h *InputHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	return "What travel question do you have?", nil
+}
+
+func (h *InputHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	return "Plan my trip to Thailand", nil
+}
+
+func (h *InputHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	ctx.SharedData["user_input"] = execResult.(string)
+	return "validate", nil, nil
+}
+
+type GuardrailHandler struct{}
+
+func (h *GuardrailHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	input, _ := ctx.SharedData["user_input"].(string)
+	return input, nil
+}
+
+func (h *GuardrailHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	input := prepResult.(string)
+	valid := strings.Contains(strings.ToLower(input), "travel") || strings.Contains(strings.ToLower(input), "trip")
+	return valid, nil
+}
+
+func (h *GuardrailHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	if execResult.(bool) {
+		return "process", nil, nil
+	}
+	return "retry", nil, nil
+}
+
+type LLMHandler struct{}
+
+func (h *LLMHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	input, _ := ctx.SharedData["user_input"].(string)
+	return input, nil
+}
+
+func (h *LLMHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	return "Here is travel advice using mock LLM", nil
+}
+
+func (h *LLMHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	return "continue", nil, nil
+}
+
+func CreateGuardrailFlow() core.Flow {
+	inputNode := impl.NewNode("input", map[string]interface{}{})
+	guardNode := impl.NewNode("guard", map[string]interface{}{})
+	llmNode := impl.NewNode("llm", map[string]interface{}{})
+
+	flow := impl.NewFlowBuilder("guardrail").
+		Begin(inputNode).
+		Then(guardNode).
+		On("process").Then(llmNode).
+		On("retry").Then(inputNode).
+		From(llmNode).On("continue").Then(inputNode).
+		Build()
+
+	return flow
+}

--- a/go/event/examples/memory/memory_flow.go
+++ b/go/event/examples/memory/memory_flow.go
@@ -1,0 +1,136 @@
+package memory
+
+import (
+	"fmt"
+	"github.com/The-Pocket/PocketFlow/go/event/core"
+	"github.com/The-Pocket/PocketFlow/go/event/impl"
+	"strings"
+)
+
+// Ensure handlers implement the interface
+var _ core.SimpleNodeHandler = (*QuestionHandler)(nil)
+var _ core.SimpleNodeHandler = (*RetrieveHandler)(nil)
+var _ core.SimpleNodeHandler = (*AnswerHandler)(nil)
+var _ core.SimpleNodeHandler = (*EmbedHandler)(nil)
+
+type QuestionHandler struct{}
+
+func (h *QuestionHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	// In this demo, we simply return a prompt string
+	prompt := "What is your question?"
+	if val, ok := ctx.Params["prompt"]; ok {
+		if s, ok := val.(string); ok && s != "" {
+			prompt = s
+		}
+	}
+	return prompt, nil
+}
+
+func (h *QuestionHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	// For the example we simulate user input
+	_ = prepResult.(string)
+	return "Tell me about memory", nil
+}
+
+func (h *QuestionHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	question := execResult.(string)
+	ctx.SharedData["last_question"] = question
+	messages, _ := ctx.SharedData["messages"].([][2]string)
+	ctx.SharedData["messages"] = messages
+	return "retrieve", question, nil
+}
+
+type RetrieveHandler struct{}
+
+func (h *RetrieveHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	question, _ := ctx.SharedData["last_question"].(string)
+	archive, _ := ctx.SharedData["archive"].([][2]string)
+	return map[string]interface{}{"q": question, "archive": archive}, nil
+}
+
+func (h *RetrieveHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	data := prepResult.(map[string]interface{})
+	question := data["q"].(string)
+	archive := data["archive"].([][2]string)
+
+	for _, pair := range archive {
+		if strings.Contains(strings.ToLower(pair[0]), strings.ToLower(question)) {
+			return pair, nil
+		}
+	}
+	return nil, nil
+}
+
+func (h *RetrieveHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	if pair, ok := execResult.([2]string); ok {
+		ctx.SharedData["retrieved"] = pair
+	}
+	return "answer", nil, nil
+}
+
+type AnswerHandler struct{}
+
+func (h *AnswerHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	question, _ := ctx.SharedData["last_question"].(string)
+	retrieved, _ := ctx.SharedData["retrieved"].([2]string)
+	return map[string]interface{}{"q": question, "retrieved": retrieved}, nil
+}
+
+func (h *AnswerHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	data := prepResult.(map[string]interface{})
+	question := data["q"].(string)
+	retrieved, _ := data["retrieved"].([2]string)
+
+	answer := "This is a response using memory"
+	if retrieved != [2]string{} {
+		answer = fmt.Sprintf("Recalling '%s' then answering: %s", retrieved[0], question)
+	}
+	return answer, nil
+}
+
+func (h *AnswerHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	answer := execResult.(string)
+	messages, _ := ctx.SharedData["messages"].([][2]string)
+	messages = append(messages, [2]string{ctx.SharedData["last_question"].(string), answer})
+	ctx.SharedData["messages"] = messages
+	if len(messages) > 3 {
+		archive, _ := ctx.SharedData["archive"].([][2]string)
+		archive = append(archive, messages[0])
+		ctx.SharedData["archive"] = archive
+		ctx.SharedData["messages"] = messages[1:]
+		return "embed", nil, nil
+	}
+	return "question", nil, nil
+}
+
+type EmbedHandler struct{}
+
+func (h *EmbedHandler) Prep(ctx core.NodeContext) (interface{}, error) {
+	return nil, nil
+}
+
+func (h *EmbedHandler) Exec(ctx core.NodeContext, prepResult interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (h *EmbedHandler) Post(ctx core.NodeContext, prepResult, execResult interface{}) (string, interface{}, error) {
+	return "question", nil, nil
+}
+
+func CreateMemoryFlow() core.Flow {
+	qNode := impl.NewNode("question", map[string]interface{}{})
+	retrieveNode := impl.NewNode("retrieve", map[string]interface{}{})
+	answerNode := impl.NewNode("answer", map[string]interface{}{})
+	embedNode := impl.NewNode("embed", map[string]interface{}{})
+
+	flow := impl.NewFlowBuilder("memory").
+		Begin(qNode).
+		Then(retrieveNode).
+		Then(answerNode).
+		On("embed").Then(embedNode).
+		On("question").From(embedNode).Then(qNode).
+		From(answerNode).On("question").Then(qNode).
+		Build()
+
+	return flow
+}

--- a/go/main.go
+++ b/go/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/The-Pocket/PocketFlow/go/event"
 	"github.com/The-Pocket/PocketFlow/go/event/core"
 	"github.com/The-Pocket/PocketFlow/go/event/examples/branching"
+	"github.com/The-Pocket/PocketFlow/go/event/examples/guardrail"
+	"github.com/The-Pocket/PocketFlow/go/event/examples/memory"
 	"github.com/The-Pocket/PocketFlow/go/event/examples/qa"
 	"github.com/The-Pocket/PocketFlow/go/event/impl"
 	"github.com/rs/zerolog"
@@ -20,7 +22,7 @@ import (
 
 func main() {
 	// Parse command-line flags
-	flowType := flag.String("flow", "basic", "Flow type to run (basic, qa, branching)")
+	flowType := flag.String("flow", "basic", "Flow type to run (basic, qa, branching, memory, guardrail)")
 	visualizeOnly := flag.Bool("visualize", false, "Only visualize the flow without running it")
 	flag.Parse()
 
@@ -79,6 +81,16 @@ func main() {
 	case "branching":
 		flowName = "Branching Intent Flow"
 		flow = branching.CreateBranchingFlow()
+		runner.RegisterFlow(flow)
+
+	case "memory":
+		flowName = "Chat Memory Flow"
+		flow = memory.CreateMemoryFlow()
+		runner.RegisterFlow(flow)
+
+	case "guardrail":
+		flowName = "Chat Guardrail Flow"
+		flow = guardrail.CreateGuardrailFlow()
 		runner.RegisterFlow(flow)
 
 	default:


### PR DESCRIPTION
## Summary
- document new Go cookbook examples for memory and guardrails
- implement `CreateMemoryFlow` and `CreateGuardrailFlow`
- register the new flows in `go/main.go`

## Testing
- `pip install -e .` *(fails: Could not find suitable setuptools)*
- `python -m unittest tests/test_flow_basic.py`
- `python -m unittest discover tests`
